### PR TITLE
Support root configs in repos named `.github`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,19 @@ Note that the files must be at the **exact same location** within the
 repositories. Configs are shallow-merged, nested objects have to be redefined
 completely.
 
+However, if a base repository is named `.github`, the config may optionally be
+stored relative to the root of the repository rather than relative a `.github/`
+directory.
+
+```yaml
+# octocat/repo1:.github/test.yaml
+_extends: .github
+other: FFF
+
+# octocat/.github:test.yaml
+other: GGG
+```
+
 ## Usage
 
 ```js

--- a/lib/index.js
+++ b/lib/index.js
@@ -94,6 +94,11 @@ async function getConfig(context, fileName, defaultConfig) {
   }
 
   const baseParams = getBaseParams(params, config[BASE_KEY]);
+  if (baseParams.repo === '.github') {
+    // In the case of a repo named `.github`, the root should be used as the
+    // relative path of the config.
+    baseParams.path = fileName;
+  }
   const baseConfig = await loadYaml(context, baseParams);
 
   delete config[BASE_KEY];

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -210,3 +210,24 @@ test('throws on an invalid base', async () => {
     expect(e.message).toMatch(/nope:/);
   }
 });
+
+test('uses the root directory on a .github repo', async () => {
+  const spy = fn()
+    .mockImplementationOnce(() => 'foo: foo\nbar: bar\n_extends: .github')
+    .mockImplementationOnce(() => 'bar: bar2\nbaz: baz');
+
+  const config = await getConfig(mockContext(spy), 'test.yml');
+  expect(config).toEqual({ foo: 'foo', bar: 'bar', baz: 'baz' });
+
+  expect(spy).toHaveBeenCalledTimes(2);
+  expect(spy).toHaveBeenCalledWith({
+    owner: 'owner',
+    repo: 'repo',
+    path: '.github/test.yml',
+  });
+  expect(spy).toHaveBeenLastCalledWith({
+    owner: 'owner',
+    repo: '.github',
+    path: 'test.yml',
+  });
+});


### PR DESCRIPTION
This change adds special support for base repos that are named
`.github`.  In these repositories, configs can be stored in the
`.github/` directory as usual, *or* directly in the root of the
repository.

Issue: #1 