### PR TITLE
docs(README): notice on archival

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# This project has been moved to Probot core
+
+This project has been merged into [Probot](https://github.com/probot/probot) itself as part of the core `context.config` helper. Any future development takes place there.
+
 # Probot: Config
 
 [![Downloads][npm-downloads]][npm-url] [![version][npm-version]][npm-url]


### PR DESCRIPTION
Adds a note to the top of the README that future development has moved to the core Probot project.

-----
[View rendered README.md](https://github.com/MikaelSmith/probot-config/blob/archive-proj/README.md)